### PR TITLE
Fix bug in children slicing

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ function search(root, test, callback) {
 
         nodes = callback(
             children[start],
-            children.slice(start + 1, end - start + 1),
+            children.slice(start + 1, end),
             children[end],
             {
                 'parent': root,

--- a/test.js
+++ b/test.js
@@ -271,4 +271,18 @@ describe('mdast-util-heading-range(heading, callback)', function () {
             done(exception);
         });
     });
+
+    it('should call back with the correct number of children', function (done) {
+        var seen;
+        mdast().use(function (processor) {
+            processor.use(heading('foo', function (start, nodes, end) {
+                seen = nodes;
+                return null;
+            }));
+        }).process('a\n\na\n\na\n\na\n\na\n\n## Foo\n\none\n\ntwo\n\nthree\n\n## Bar', function (exception, file, doc) {
+            equal(seen.length, 3);
+            done(exception);
+        });
+    });
+
 });


### PR DESCRIPTION
your usage of `Array.prototype.slice` is incorrect. Your arguments seem to think that the interface is `slice(startIndex :: number, sliceLength :: number)` but it is actually `slice(startIndex :: number, exclusiveEndIndex :: number`. See the MDN docs for more info: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice

This pull request adds a failing test case for this bug (https://github.com/wooorm/mdast-util-heading-range/commit/a88b2c4f835803fc85485dd47d421b632a4fb3e0)
and then corrects the problem (https://github.com/wooorm/mdast-util-heading-range/commit/13f1349fd067b98d869c842bfc422cbb4a6bba09)

current users can work around this until you release a new version by doing their own slicing:

``` javascript
function visitor(start, garbageNodesDoNotUse, end, extra) {
  const nodesStart = extra.start + 1;
  const nodesEnd = extra.end === null ? extra.parent.children.length + 1 : extra.end;
  const nodes = extra.parent.children.slice(nodesStart, nodesEnd);
  // ...
}
```
